### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,6 +24,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/jamesmoore/chatgpt-export/security/code-scanning/2](https://github.com/jamesmoore/chatgpt-export/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to the `build` job in `.github/workflows/docker-publish.yml`. This block should specify the minimum permissions required for the job to function. Since the `build` job only checks out code, restores dependencies, builds, and tests, it only needs read access to repository contents. Therefore, add `permissions: contents: read` under the `build` job, at the same indentation level as `runs-on`. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
