### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,9 @@
 
 name: .NET Build
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jamesmoore/chatgpt-export/security/code-scanning/1](https://github.com/jamesmoore/chatgpt-export/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file. Since none of the steps in the workflow require write access to the repository or other resources, the minimal required permission is `contents: read`. This block can be added at the root level of the workflow (above `jobs:`) to apply to all jobs, or at the job level if different jobs require different permissions. In this case, adding it at the root level is sufficient and recommended. No additional imports or definitions are needed; simply insert the following block after the `name:` field and before the `on:` field:

```yaml
permissions:
  contents: read
```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
