### PR TITLE
fix: correct typo in source description

### DIFF
--- a/ChatGPTExport/Program.cs
+++ b/ChatGPTExport/Program.cs
@@ -13,7 +13,7 @@ const string searchPattern = "conversations.json";
 var sourceDirectoryOption = new Option<DirectoryInfo[]>("--source", "-s")
 {
     Description = """
-    The source directory/directories containing the unzipped ChatGTP exported files.
+    The source directory/directories containing the unzipped ChatGPT exported files.
     Must contain at least one conversations.json, in the folder or one of its subfolders.
     You can specify a parent directory containing multiple exports.
     You can also specify multiple source directories (eg, -s dir1 -s dir2), and they will be processed in sequence.


### PR DESCRIPTION
## Summary
- fix typo in source directory option description

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_689cd3317054832f9b6b2b535f3d97f5