### PR TITLE
Add array length assertion in JsonComparer array diff test

### DIFF
--- a/ChatGTPExportTests/Validators/JsonComparerTests.cs
+++ b/ChatGTPExportTests/Validators/JsonComparerTests.cs
@@ -157,6 +157,7 @@ namespace ChatGTPExportTests.Validators
 
             var diff = JsonComparer.CompareJson(json, json2);
             Assert.NotEmpty(diff);
+            Assert.Contains("Array length differs", diff[0]);
         }
     }
 }


### PR DESCRIPTION
## Summary
- assert that JsonComparer reports array length differences

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689cd5d9f7d4832fa145315e7b6c9882