### PR TITLE
Validate asset search pattern and add tests

### DIFF
--- a/ChatGPTExport/Assets/ExistingAssetLocator.cs
+++ b/ChatGPTExport/Assets/ExistingAssetLocator.cs
@@ -25,7 +25,17 @@ namespace ChatGPTExport.Assets
 
         public string? GetMarkdownMediaAsset(AssetRequest assetRequest)
         {
-            // it may already exist in the destination directory from a previous export 
+            var invalidChars = fileSystem.Path.GetInvalidFileNameChars()
+                .Concat(new[] { '*', '?', fileSystem.Path.DirectorySeparatorChar, fileSystem.Path.AltDirectorySeparatorChar })
+                .Distinct()
+                .ToArray();
+
+            if (assetRequest.SearchPattern.IndexOfAny(invalidChars) >= 0)
+            {
+                return null;
+            }
+
+            // it may already exist in the destination directory from a previous export
             var destinationMatches = GetCachedDestinationFiles(assetRequest.SearchPattern).ToList();
             if (destinationMatches.Count == 0)
             {

--- a/ChatGTPExportTests/Assets/ExistingAssetLocatorTests.cs
+++ b/ChatGTPExportTests/Assets/ExistingAssetLocatorTests.cs
@@ -1,0 +1,47 @@
+using ChatGPTExport.Assets;
+using System.IO.Abstractions.TestingHelpers;
+
+namespace ChatGTPExportTests.Assets
+{
+    public class ExistingAssetLocatorTests
+    {
+        [Theory]
+        [InlineData("image*")]
+        [InlineData("image?")]
+        [InlineData("image/")]
+        [InlineData("image\\")]
+        [InlineData("invali<d")]
+        public void GetMarkdownMediaAsset_InvalidPattern_ReturnsNull(string pattern)
+        {
+            var fs = new MockFileSystem();
+            var destPath = fs.Path.Combine(fs.Path.DirectorySeparatorChar.ToString(), "dest");
+            fs.AddDirectory(destPath);
+            var destDir = fs.DirectoryInfo.New(destPath);
+            var locator = new ExistingAssetLocator(fs, destDir);
+
+            var request = new AssetRequest(pattern, "role", null, null);
+            var result = locator.GetMarkdownMediaAsset(request);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetMarkdownMediaAsset_ValidPattern_ReturnsMarkdown()
+        {
+            var fs = new MockFileSystem();
+            var destPath = fs.Path.Combine(fs.Path.DirectorySeparatorChar.ToString(), "dest");
+            fs.AddDirectory(destPath);
+            var filePath = fs.Path.Combine(destPath, "image1.png");
+            fs.AddFile(filePath, new MockFileData("data"));
+
+            var destDir = fs.DirectoryInfo.New(destPath);
+            var locator = new ExistingAssetLocator(fs, destDir);
+
+            var request = new AssetRequest("image1", "role", null, null);
+            var result = locator.GetMarkdownMediaAsset(request);
+
+            Assert.NotNull(result);
+            Assert.Contains("image1.png", result);
+        }
+    }
+}

--- a/ChatGTPExportTests/ChatGTPExportTests.csproj
+++ b/ChatGTPExportTests/ChatGTPExportTests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="22.0.15" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Validate asset search patterns against invalid characters, wildcards, and path separators before scanning for existing files
- Add tests covering invalid patterns and successful lookups

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfdf46bcbc832f99ec85581ba50304