### PR TITLE
Add FileSystemExtensions tests using explicit comparer

### DIFF
--- a/ChatGTPExportTests/FileSystemExtensionsTests.cs
+++ b/ChatGTPExportTests/FileSystemExtensionsTests.cs
@@ -1,0 +1,33 @@
+using System.IO.Abstractions.TestingHelpers;
+using ChatGPTExport;
+
+namespace ChatGTPExportTests
+{
+    public class FileSystemExtensionsTests
+    {
+        private static MockFileSystem CreateFileSystem(bool caseSensitive)
+        {
+            var comparer = caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+            var files = new Dictionary<string, MockFileData>(comparer);
+            return new MockFileSystem(files, "/");
+        }
+
+        private static void ResetCache()
+        {
+            typeof(FileSystemExtensions)
+                .GetField("_isCaseSensitive", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)!
+                .SetValue(null, null);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void IsFileSystemCaseSensitive_ReturnsExpected(bool caseSensitive)
+        {
+            ResetCache();
+            var fileSystem = CreateFileSystem(caseSensitive);
+            var result = fileSystem.IsFileSystemCaseSensitive();
+            Assert.Equal(caseSensitive, result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add FileSystemExtensions tests
- ensure file system mock uses comparer-aware dictionary and root path

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfef501e6c832fb58695c993edb540