### PR TITLE
enable linting

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -6,7 +6,7 @@ RUN cd front-react && npm ci
 
 COPY front-react/ front-react/
 COPY ChatGPTExport/Formatters/Html/Templates/ ChatGPTExport/Formatters/Html/Templates/
-RUN npm run lint && npm run build
+RUN cd front-react && npm run lint && npm run build
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build-env
 ARG VERSION

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -6,7 +6,8 @@ RUN cd front-react && npm ci
 
 COPY front-react/ front-react/
 COPY ChatGPTExport/Formatters/Html/Templates/ ChatGPTExport/Formatters/Html/Templates/
-RUN cd front-react && npm run build
+WORKDIR /app/front-react
+RUN npm run lint && npm run build
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build-env
 ARG VERSION

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -6,7 +6,6 @@ RUN cd front-react && npm ci
 
 COPY front-react/ front-react/
 COPY ChatGPTExport/Formatters/Html/Templates/ ChatGPTExport/Formatters/Html/Templates/
-WORKDIR /app/front-react
 RUN npm run lint && npm run build
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build-env

--- a/front-react/src/hooks/use-mobile.ts
+++ b/front-react/src/hooks/use-mobile.ts
@@ -1,19 +1,20 @@
-import * as React from "react"
+import { useEffect, useState } from "react"
 
 const MOBILE_BREAKPOINT = 768
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+  const [isMobile, setIsMobile] = useState(
+    () => window.innerWidth < MOBILE_BREAKPOINT,
+  )
 
-  React.useEffect(() => {
+  useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    const onChange = (event: MediaQueryListEvent) => {
+      setIsMobile(event.matches)
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
     return () => mql.removeEventListener("change", onChange)
   }, [])
 
-  return !!isMobile
+  return isMobile
 }


### PR DESCRIPTION
This pull request introduces improvements to the frontend build process and refines the `useIsMobile` React hook for better performance and accuracy. The most important changes are:

**Frontend Build Process:**

* The Docker build process now sets the working directory to `front-react` and runs a lint check before building, ensuring code quality is enforced during builds. (`Dockerfile.api`)

**React Hook Improvements:**

* The `useIsMobile` hook is refactored to:
  - Use direct imports for `useEffect` and `useState` instead of importing all of React.
  - Initialize `isMobile` based on the current window width for immediate accuracy.
  - Update the event listener to use the `matches` property of the media query event for more reliable detection.
  - Remove unnecessary double-checks and ensure the return value is always a boolean. (`front-react/src/hooks/use-mobile.ts`)