### PR TITLE
handle text content with no parts

### DIFF
--- a/ChatGPTExport/Decoders/ContentTextDecoder.cs
+++ b/ChatGPTExport/Decoders/ContentTextDecoder.cs
@@ -19,6 +19,11 @@ namespace ChatGPTExport.Decoders
 
             var parts = content.parts?.Where(TextContentFilter).SelectMany(p => DecodeText(p, context)).ToList() ?? [];
 
+            if (parts.Count == 0)
+            {
+                return MarkdownContentResult.Empty();
+            }
+
             var content_references = context.MessageMetadata.content_references;
             if (content_references != null && content_references.Length != 0)
             {
@@ -83,7 +88,7 @@ namespace ChatGPTExport.Decoders
                 }
             }
 
-            var markdownContent = parts.Select(UnwrapWritingBlock).ToList(); 
+            var markdownContent = parts.Select(UnwrapWritingBlock).ToList();
 
             return MarkdownContentResult.FromLines(markdownContent);
         }


### PR DESCRIPTION
This pull request introduces a small but important change to the `Decode` method in `ContentTextDecoder.cs`. Now, if the decoded `parts` list is empty, the method will immediately return an empty `MarkdownContentResult`, ensuring that no further processing occurs for empty content.

- Early return for empty content:
  * `Decode` method in `ContentTextDecoder.cs` now returns `MarkdownContentResult.Empty()` if the decoded `parts` list is empty, preventing unnecessary processing.